### PR TITLE
Updated evolution auto apply to a non-deprecated configuration.

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -16,8 +16,6 @@ play.i18n.langs = [ "en" ]
 
 ebean.default=["io.pathfinder.models.*"]
 
-applyEvolutions.default=true
-
 ## Local DB settings
 db.default.driver=org.h2.Driver
 db.default.url="jdbc:h2:mem:play;MODE=PostgreSQL;DB_CLOSE_DELAY=-1"
@@ -30,6 +28,7 @@ db.default.url="jdbc:h2:mem:play;MODE=PostgreSQL;DB_CLOSE_DELAY=-1"
 #db.default.hikaricp.connectionTestQuery="SELECT 1"
 
 play.evolutions.enabled=true
+play.evolutions.db.default.autoApply=true
 
 play.filters.cors {
   allowedOrigins = null


### PR DESCRIPTION
applyEvolutions.default=true is deprecated.
play.evolutions.db.default.autoApply=true is the new version.
