### PR TITLE
Fixed Ebean Postgres syntax errors.

### DIFF
--- a/app/io/pathfinder/data/EbeanCrudDao.scala
+++ b/app/io/pathfinder/data/EbeanCrudDao.scala
@@ -2,6 +2,7 @@ package io.pathfinder.data
 
 import com.avaje.ebean.Model
 import play.db.ebean.Transactional
+import play.Logger
 import scala.collection.JavaConversions.asScalaBuffer
 
 class EbeanCrudDao[K,M <: Model](protected val finder: Model.Find[K,M]) extends CrudDao[K,M] {
@@ -13,7 +14,8 @@ class EbeanCrudDao[K,M <: Model](protected val finder: Model.Find[K,M]) extends 
 
     final def create(create: Resource[M]): Option[M] = {
         create.create().map {
-            model =>
+            (model: M) =>
+                Logger.info(String.format("EbeanCrudDao inserting new %s: %s", model.getClass.getName, model))
                 model.insert()
                 model
         }

--- a/app/io/pathfinder/models/Cluster.scala
+++ b/app/io/pathfinder/models/Cluster.scala
@@ -73,6 +73,9 @@ class Cluster() extends Model {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long = 0
 
+    @Column
+    var authenticationToken: String = "top secret"
+
     @OneToMany(mappedBy = "cluster", cascade=Array(CascadeType.ALL))
     var vehicleList: util.List[Vehicle] = new util.ArrayList[Vehicle]()
 
@@ -81,4 +84,10 @@ class Cluster() extends Model {
 
     def vehicles: mutable.Buffer[Vehicle] = vehicleList.asScala
     def commodities: mutable.Buffer[Commodity] = commodityList.asScala
+
+    override def toString = String.format(
+        "Cluster(id: %s, vehicles: %s, commodities: %s)",
+        id.toString,
+        util.Arrays.toString(vehicleList.toArray),
+        util.Arrays.toString(commodityList.toArray))
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -25,7 +25,8 @@ db.default.url="jdbc:h2:mem:play;MODE=PostgreSQL;DB_CLOSE_DELAY=-1"
 #db.default.url="jdbc:postgresql://162.222.177.187:5432/pathfinderdb?ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory"
 #db.default.username=""
 #db.default.password=""
-#db.default.hikaricp.connectionTestQuery="SELECT 1"
+#play.db.pool="bonecp"
+#db.default.logStatements=true
 
 play.evolutions.enabled=true
 play.evolutions.db.default.autoApply=true

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -14,6 +14,7 @@
   -->
   <logger name="play" level="INFO" />
   <logger name="application" level="DEBUG" />
+  <logger name="com.jolbox.bonecp" level="DEBUG" />
 
   <root level="ERROR">
     <appender-ref ref="STDOUT" />


### PR DESCRIPTION
As it turns out, if there are no columns in your table, Ebeans generates an invalid query. So I added an auth field to the Cluster model.

Also, I changed our db connection pool from HikariCP to BoneCP b/c BoneCP supports logging all SQL commands while HikariCP does not.
