### PR TITLE
Feature/application support

### DIFF
--- a/app/io/pathfinder/config/Global.java
+++ b/app/io/pathfinder/config/Global.java
@@ -1,5 +1,7 @@
 package io.pathfinder.config;
 
+import io.pathfinder.models.Cluster;
+import io.pathfinder.models.PathFinderApplication;
 import io.pathfinder.routing.Router;
 import play.Application;
 import play.GlobalSettings;

--- a/app/io/pathfinder/controllers/ClusterController.java
+++ b/app/io/pathfinder/controllers/ClusterController.java
@@ -1,23 +1,16 @@
 package io.pathfinder.controllers;
 
-import com.avaje.ebean.Ebean;
-import com.avaje.ebean.text.json.JsonContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.pathfinder.models.Cluster;
 import play.Logger;
 import play.api.libs.json.JsValue;
-import play.libs.Json;
 import play.mvc.Controller;
 import play.mvc.Result;
-import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import javax.persistence.PersistenceException;
 
 public class ClusterController extends Controller {
-    private JsonContext jsonContext = Ebean.createJsonContext();
 
     public Result getClusters() {
         List<String> jsObjs = Cluster.finder().all().stream().map(x -> Cluster.format().writes(x).toString()).collect(Collectors.toList());

--- a/app/io/pathfinder/controllers/PathFinderApplicationController.scala
+++ b/app/io/pathfinder/controllers/PathFinderApplicationController.scala
@@ -1,0 +1,13 @@
+package io.pathfinder.controllers
+
+import io.pathfinder.models.PathFinderApplication
+import play.api.mvc.{Action, Controller}
+
+class PathFinderApplicationController extends Controller {
+
+    def get(id: String) = Action {
+        Option(PathFinderApplication.finder.byId(id)).map {
+            app => Ok(PathFinderApplication.format.writes(app))
+        }.getOrElse(NotFound("No Application with id: "+id))
+    }
+}

--- a/app/io/pathfinder/controllers/PathFinderApplicationController.scala
+++ b/app/io/pathfinder/controllers/PathFinderApplicationController.scala
@@ -1,11 +1,13 @@
 package io.pathfinder.controllers
 
+import java.util.UUID
+
 import io.pathfinder.models.PathFinderApplication
 import play.api.mvc.{Action, Controller}
 
 class PathFinderApplicationController extends Controller {
 
-    def get(id: String) = Action {
+    def get(id: UUID) = Action {
         Option(PathFinderApplication.finder.byId(id)).map {
             app => Ok(PathFinderApplication.format.writes(app))
         }.getOrElse(NotFound("No Application with id: "+id))

--- a/app/io/pathfinder/models/Cluster.scala
+++ b/app/io/pathfinder/models/Cluster.scala
@@ -82,10 +82,6 @@ class Cluster() extends Model {
     @OneToMany(mappedBy = "cluster", cascade=Array(CascadeType.ALL))
     var commodityList: util.List[Commodity] = new util.ArrayList[Commodity]()
 
-    @ManyToOne
-    @JoinColumn
-    var pathFinderApplication: PathFinderApplication = null
-
     def vehicles: mutable.Buffer[Vehicle] = vehicleList.asScala
     def commodities: mutable.Buffer[Commodity] = commodityList.asScala
 

--- a/app/io/pathfinder/models/Cluster.scala
+++ b/app/io/pathfinder/models/Cluster.scala
@@ -1,7 +1,7 @@
 package io.pathfinder.models
 
 import java.util
-import javax.persistence.{OneToMany, CascadeType, Id, GenerationType, Column, GeneratedValue, Entity}
+import javax.persistence.{JoinColumn, ManyToOne, OneToMany, CascadeType, Id, GenerationType, Column, GeneratedValue, Entity}
 
 import com.avaje.ebean.Model
 import io.pathfinder.data.{Resource, EbeanCrudDao}
@@ -81,6 +81,10 @@ class Cluster() extends Model {
 
     @OneToMany(mappedBy = "cluster", cascade=Array(CascadeType.ALL))
     var commodityList: util.List[Commodity] = new util.ArrayList[Commodity]()
+
+    @ManyToOne
+    @JoinColumn
+    var pathFinderApplication: PathFinderApplication = null
 
     def vehicles: mutable.Buffer[Vehicle] = vehicleList.asScala
     def commodities: mutable.Buffer[Commodity] = commodityList.asScala

--- a/app/io/pathfinder/models/PathFinderApplication.scala
+++ b/app/io/pathfinder/models/PathFinderApplication.scala
@@ -1,35 +1,28 @@
 package io.pathfinder.models
 
-import java.util
 import java.util.UUID
-import javax.persistence.{CascadeType, OneToMany, JoinColumn, Column, OneToOne, Id, Entity}
+import javax.persistence.{ManyToOne, JoinColumn, Column, Id, Entity}
 import com.avaje.ebean.Model
 import com.avaje.ebean.Model.{Finder, Find}
-import play.api.libs.json.{Writes, Json, Format}
+import play.api.libs.json.{Json, Format}
 
-import scala.collection.mutable
-import scala.collection.JavaConverters.asScalaBufferConverter
 
 
 object PathFinderApplication {
-    val finder: Find[String, PathFinderApplication] =
-        new Finder[String, PathFinderApplication](classOf[PathFinderApplication])
+    val finder: Find[UUID, PathFinderApplication] =
+        new Finder[UUID, PathFinderApplication](classOf[PathFinderApplication])
 
     val format: Format[PathFinderApplication] = Json.format[PathFinderApplication]
 
-    def apply(id: UUID, name: String, defaultClusterId: Long, clusterIds: Seq[Long]): PathFinderApplication = {
+    def apply(id: UUID, name: String, defaultClusterId: Long): PathFinderApplication = {
         val app = new PathFinderApplication
         app.id = id
-        app.defaultCluster = Cluster.Dao.read(defaultClusterId).get
-        Cluster.Dao.readAll(clusterIds).fold(
-            id => throw new IllegalArgumentException("No Cluster with id: " + id),
-            app.clusters ++= _
-        )
+        app.cluster = Cluster.Dao.read(defaultClusterId).get
         app
     }
 
-    def unapply(p: PathFinderApplication): Option[(UUID, String, Long, Seq[Long])] =
-        Some((p.id, p.name, Option(p.defaultCluster).map(_.id).getOrElse(0L), p.clusters.map(_.id)))
+    def unapply(p: PathFinderApplication): Option[(UUID, String, Long)] =
+        Some((p.id, p.name, Option(p.cluster).map(_.id).getOrElse(0L)))
 }
 
 @Entity
@@ -42,12 +35,7 @@ class PathFinderApplication extends Model {
     @Column
     var name: String = null
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn
-    var defaultCluster: Cluster = null
-
-    @OneToMany(cascade=Array(CascadeType.ALL))
-    var clusterList: util.List[Cluster] = new util.ArrayList[Cluster]()
-
-    def clusters: mutable.Buffer[Cluster] = clusterList.asScala
+    var cluster: Cluster = null
 }

--- a/app/io/pathfinder/models/PathFinderApplication.scala
+++ b/app/io/pathfinder/models/PathFinderApplication.scala
@@ -1,0 +1,53 @@
+package io.pathfinder.models
+
+import java.util
+import java.util.UUID
+import javax.persistence.{CascadeType, OneToMany, JoinColumn, Column, OneToOne, Id, Entity}
+import com.avaje.ebean.Model
+import com.avaje.ebean.Model.{Finder, Find}
+import play.api.libs.json.{Writes, Json, Format}
+
+import scala.collection.mutable
+import scala.collection.JavaConverters.asScalaBufferConverter
+
+
+object PathFinderApplication {
+    val finder: Find[String, PathFinderApplication] =
+        new Finder[String, PathFinderApplication](classOf[PathFinderApplication])
+
+    val format: Format[PathFinderApplication] = Json.format[PathFinderApplication]
+
+    def apply(id: UUID, name: String, defaultClusterId: Long, clusterIds: Seq[Long]): PathFinderApplication = {
+        val app = new PathFinderApplication
+        app.id = id
+        app.defaultCluster = Cluster.Dao.read(defaultClusterId).get
+        Cluster.Dao.readAll(clusterIds).fold(
+            id => throw new IllegalArgumentException("No Cluster with id: " + id),
+            app.clusters ++= _
+        )
+        app
+    }
+
+    def unapply(p: PathFinderApplication): Option[(UUID, String, Long, Seq[Long])] =
+        Some((p.id, p.name, Option(p.defaultCluster).map(_.id).getOrElse(0L), p.clusters.map(_.id)))
+}
+
+@Entity
+class PathFinderApplication extends Model {
+
+    @Id
+    @Column(updatable = false)
+    var id: UUID = null
+
+    @Column
+    var name: String = null
+
+    @OneToOne
+    @JoinColumn
+    var defaultCluster: Cluster = null
+
+    @OneToMany(cascade=Array(CascadeType.ALL))
+    var clusterList: util.List[Cluster] = new util.ArrayList[Cluster]()
+
+    def clusters: mutable.Buffer[Cluster] = clusterList.asScala
+}

--- a/app/io/pathfinder/models/Vehicle.scala
+++ b/app/io/pathfinder/models/Vehicle.scala
@@ -3,7 +3,7 @@ package io.pathfinder.models
 
 import com.avaje.ebean.Model
 import io.pathfinder.websockets.WebSocketDao
-import javax.persistence.{ManyToOne, Id, Column, Entity, GeneratedValue, GenerationType}
+import javax.persistence.{JoinColumn, ManyToOne, Id, Column, Entity, GeneratedValue, GenerationType}
 import play.api.libs.json.{Format,Json}
 import io.pathfinder.data.{ClusterQueries, Resource}
 
@@ -88,6 +88,6 @@ class Vehicle() extends Model {
     var capacity: Int = 0
 
     @ManyToOne
-    @Column
+    @JoinColumn
     var cluster: Cluster = null
 }

--- a/app/io/pathfinder/websockets/WebSocketActor.scala
+++ b/app/io/pathfinder/websockets/WebSocketActor.scala
@@ -1,7 +1,7 @@
 package io.pathfinder.websockets
 
 import akka.actor.{Props, Actor, ActorRef}
-import io.pathfinder.models.{Vehicle, Commodity}
+import io.pathfinder.models.{PathFinderApplication, Vehicle, Commodity}
 import io.pathfinder.routing.Router
 import io.pathfinder.websockets.ModelTypes.ModelType
 import io.pathfinder.websockets.controllers.VehicleSocketController._
@@ -64,6 +64,9 @@ class WebSocketActor (
                     ) getOrElse Error("Could not parse json in " + ModelTypes.Vehicle + " Create Request")
                 )
                 case c: ControllerMessage => controllers.get(c.model).flatMap(_.receive(c)).foreach(client ! _)
+                case GetClusters(id) => client ! Option(PathFinderApplication.finder.byId(id)).map {
+                    app => Clusters(id, app.defaultCluster.id, app.clusters.map(_.id))
+                }.getOrElse(Error("No Application with id: "+id))
                 case Subscribe(cluster, model, event, id) => {
                     client ! Error("Not Implemented")
                 }

--- a/app/io/pathfinder/websockets/WebSocketActor.scala
+++ b/app/io/pathfinder/websockets/WebSocketActor.scala
@@ -64,8 +64,8 @@ class WebSocketActor (
                     ) getOrElse Error("Could not parse json in " + ModelTypes.Vehicle + " Create Request")
                 )
                 case c: ControllerMessage => controllers.get(c.model).flatMap(_.receive(c)).foreach(client ! _)
-                case GetClusters(id) => client ! Option(PathFinderApplication.finder.byId(id)).map {
-                    app => Clusters(id, app.defaultCluster.id, app.clusters.map(_.id))
+                case GetApplicationCluster(id) => client ! Option(PathFinderApplication.finder.byId(id)).map {
+                    app => ApplicationCluster(id, app.cluster.id)
                 }.getOrElse(Error("No Application with id: "+id))
                 case Subscribe(cluster, model, event, id) => {
                     client ! Error("Not Implemented")

--- a/app/io/pathfinder/websockets/WebSocketMessage.scala
+++ b/app/io/pathfinder/websockets/WebSocketMessage.scala
@@ -120,8 +120,8 @@ object WebSocketMessage {
 
   case class Clusters(
     id: String,
-    defaultCluster: Long,
-    clusters: Seq[Long]
+    defaultClusterId: Long,
+    clusterIds: Seq[Long]
   ) extends WebSocketMessage
   implicit  val clustersFormat = Json.format[Clusters]
   /**

--- a/app/io/pathfinder/websockets/WebSocketMessage.scala
+++ b/app/io/pathfinder/websockets/WebSocketMessage.scala
@@ -1,5 +1,7 @@
 package io.pathfinder.websockets
 
+import java.util.UUID
+
 import io.pathfinder.models.Cluster
 import play.api.libs.json._
 import play.api.mvc.WebSocket.FrameFormatter
@@ -113,17 +115,20 @@ object WebSocketMessage {
   /**
    * Sent by the client that wants to get the clusters for an application
    */
-  case class GetClusters(
-    id: String
+  case class GetApplicationCluster(
+    id: UUID
   ) extends WebSocketMessage
-  implicit val getClustersFormat = Json.format[GetClusters]
+  implicit val getApplicationClusterFormat = Json.format[GetApplicationCluster]
+  implicit val uuidFormat = Format[UUID](
+      Reads.StringReads.map(UUID.fromString),
+      Writes(id => Writes.StringWrites.writes(id.toString))
+  )
 
-  case class Clusters(
-    id: String,
-    defaultClusterId: Long,
-    clusterIds: Seq[Long]
+  case class ApplicationCluster(
+    id: UUID,
+    clusterId: Long
   ) extends WebSocketMessage
-  implicit  val clustersFormat = Json.format[Clusters]
+  implicit  val applicationClusterFormat = Json.format[ApplicationCluster]
   /**
    * Message sent to the client that requested a read
    */
@@ -201,8 +206,8 @@ object WebSocketMessage {
     (JsPath \ "unsubscribed").read[UnSubscribed].map(identity[WebSocketMessage]) orElse
     (JsPath \ "route").read[Route].map(identity[WebSocketMessage]) orElse
     (JsPath \ "routed").read[Routed].map(identity[WebSocketMessage]) orElse
-    (JsPath \ "getClusters").read[GetClusters].map(identity[WebSocketMessage]) orElse
-    (JsPath \ "clusters").read[Clusters].map(identity[WebSocketMessage])
+    (JsPath \ "getApplicationCluster").read[GetApplicationCluster].map(identity[WebSocketMessage]) orElse
+    (JsPath \ "applicationCluster").read[ApplicationCluster].map(identity[WebSocketMessage])
     errorFormat.map(identity[WebSocketMessage]) orElse unknownMessageFormat.map(identity[WebSocketMessage])
 
   /**
@@ -225,8 +230,8 @@ object WebSocketMessage {
       case u: UnSubscribed => (JsPath \ "unsubscribed").write(unSubscribedFormat).writes(u)
       case r: Route        => (JsPath \ "route").write(routeFormat).writes(r)
       case r: Routed       => (JsPath \ "routed").write(routedFormat).writes(r)
-      case c: GetClusters  => (JsPath \ "getClusters").write(getClustersFormat).writes(c)
-      case c: Clusters     => (JsPath \ "clusters").write(clustersFormat).writes(c)
+      case c: GetApplicationCluster => (JsPath \ "getApplicationCluster").write(getApplicationClusterFormat).writes(c)
+      case c: ApplicationCluster    => (JsPath \ "applicationCluster").write(applicationClusterFormat).writes(c)
       case e: Error        => errorFormat.writes(e)
       case u: UnknownMessage => unknownMessageFormat.writes(u)
     }

--- a/app/io/pathfinder/websockets/WebSocketMessage.scala
+++ b/app/io/pathfinder/websockets/WebSocketMessage.scala
@@ -1,5 +1,6 @@
 package io.pathfinder.websockets
 
+import io.pathfinder.models.Cluster
 import play.api.libs.json._
 import play.api.mvc.WebSocket.FrameFormatter
 
@@ -110,6 +111,20 @@ object WebSocketMessage {
   implicit val readFormat = Json.format[Read]
 
   /**
+   * Sent by the client that wants to get the clusters for an application
+   */
+  case class GetClusters(
+    id: String
+  ) extends WebSocketMessage
+  implicit val getClustersFormat = Json.format[GetClusters]
+
+  case class Clusters(
+    id: String,
+    defaultCluster: Long,
+    clusters: Seq[Long]
+  ) extends WebSocketMessage
+  implicit  val clustersFormat = Json.format[Clusters]
+  /**
    * Message sent to the client that requested a read
    */
   case class Created(
@@ -186,6 +201,8 @@ object WebSocketMessage {
     (JsPath \ "unsubscribed").read[UnSubscribed].map(identity[WebSocketMessage]) orElse
     (JsPath \ "route").read[Route].map(identity[WebSocketMessage]) orElse
     (JsPath \ "routed").read[Routed].map(identity[WebSocketMessage]) orElse
+    (JsPath \ "getClusters").read[GetClusters].map(identity[WebSocketMessage]) orElse
+    (JsPath \ "clusters").read[Clusters].map(identity[WebSocketMessage])
     errorFormat.map(identity[WebSocketMessage]) orElse unknownMessageFormat.map(identity[WebSocketMessage])
 
   /**
@@ -208,6 +225,8 @@ object WebSocketMessage {
       case u: UnSubscribed => (JsPath \ "unsubscribed").write(unSubscribedFormat).writes(u)
       case r: Route        => (JsPath \ "route").write(routeFormat).writes(r)
       case r: Routed       => (JsPath \ "routed").write(routedFormat).writes(r)
+      case c: GetClusters  => (JsPath \ "getClusters").write(getClustersFormat).writes(c)
+      case c: Clusters     => (JsPath \ "clusters").write(clustersFormat).writes(c)
       case e: Error        => errorFormat.writes(e)
       case u: UnknownMessage => unknownMessageFormat.writes(u)
     }

--- a/conf/routes
+++ b/conf/routes
@@ -20,4 +20,4 @@ GET           /cluster/:id          io.pathfinder.controllers.ClusterController.
 POST          /cluster              io.pathfinder.controllers.ClusterController.createCluster()
 DELETE        /cluster/:id          io.pathfinder.controllers.ClusterController.deleteCluster(id: Long)
 
-GET           /application/:id      io.pathfinder.controllers.PathFinderApplicationController.get(id: String)
+GET           /application/:id      io.pathfinder.controllers.PathFinderApplicationController.get(id: java.util.UUID)

--- a/conf/routes
+++ b/conf/routes
@@ -19,3 +19,5 @@ GET           /cluster              io.pathfinder.controllers.ClusterController.
 GET           /cluster/:id          io.pathfinder.controllers.ClusterController.getCluster(id: Long)
 POST          /cluster              io.pathfinder.controllers.ClusterController.createCluster()
 DELETE        /cluster/:id          io.pathfinder.controllers.ClusterController.deleteCluster(id: Long)
+
+GET           /application/:id      io.pathfinder.controllers.PathFinderApplicationController.get(id: String)

--- a/test/io/pathfinder/BaseAppTest.java
+++ b/test/io/pathfinder/BaseAppTest.java
@@ -1,12 +1,15 @@
 package io.pathfinder;
 
 import io.pathfinder.models.Cluster;
+import io.pathfinder.models.PathFinderApplication;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import play.test.FakeApplication;
 import play.test.Helpers;
+
+import java.util.UUID;
 
 /**
  * Provides the boilerplate for setting up a FakeApplication. All vehicles and commodities will
@@ -15,13 +18,20 @@ import play.test.Helpers;
 public class BaseAppTest {
     public static FakeApplication app;
     public static final Cluster cluster = new Cluster();
+    public static final PathFinderApplication pathfinderApplication = new PathFinderApplication();
+    public static final UUID APPLICATION_ID = UUID.fromString("001e7047-ee14-40d6-898a-5acf3a1cfd8a");
 
     @Before
     public void startApp() {
         app = Helpers.fakeApplication(Helpers.inMemoryDatabase());
         Helpers.start(app);
+        pathfinderApplication.id_$eq(APPLICATION_ID);
+        pathfinderApplication.name_$eq("MY COOL APP");
         cluster.id_$eq(1);
         cluster.insert();
+        pathfinderApplication.cluster_$eq(cluster);
+        pathfinderApplication.insert();
+        cluster.save();
     }
 
     @After

--- a/test/io/pathfinder/websockets/WebSocketActorTest.java
+++ b/test/io/pathfinder/websockets/WebSocketActorTest.java
@@ -15,10 +15,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import play.api.libs.json.JsValue;
 import play.api.libs.json.Json;
-import scala.collection.JavaConversions;
-
-import java.util.Arrays;
-
 
 /**
  * This test was based off of the documentation at

--- a/test/io/pathfinder/websockets/WebSocketActorTest.java
+++ b/test/io/pathfinder/websockets/WebSocketActorTest.java
@@ -15,6 +15,9 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import play.api.libs.json.JsValue;
 import play.api.libs.json.Json;
+import scala.collection.JavaConversions;
+
+import java.util.Arrays;
 
 
 /**
@@ -32,6 +35,9 @@ public class WebSocketActorTest extends BaseAppTest {
         Json.parse("{\"create\":{\"model\":\"Vehicle\",\"value\":{\"latitude\":0.1,\"longitude\":-12.3,\"clusterId\":1,\"capacity\":99}}}");
     private static final JsValue JSON_CREATE_COMMODITY =
         Json.parse("{\"create\":{\"model\":\"Commodity\",\"value\":{\"startLatitude\":0.1,\"startLongitude\":-12.3,\"endLatitude\":99.4,\"endLongitude\":-3.5,\"clusterId\":1,\"param\":5}}}");
+    private static final JsValue JSON_GET_CLUSTERS =
+        Json.parse("{\"getClusters\":{\"id\":\"ABCDEFG\"}");
+
     private static final int TIMEOUT = 3000;
 
     @Before
@@ -79,5 +85,11 @@ public class WebSocketActorTest extends BaseAppTest {
         createdCommodity.param_$eq(5);
         client.expectMsg(new WebSocketMessage.Created(
             ModelTypes.Commodity(), Commodity.format().writes(createdCommodity)));
+    }
+
+    @Test
+    public void testGetClusters() {
+        Patterns.ask(socket, WebSocketMessage.format().reads(JSON_GET_CLUSTERS).get(), TIMEOUT);
+        client.expectMsg(new WebSocketMessage.GetClusters("ABCDEFG"));
     }
 }

--- a/test/io/pathfinder/websockets/WebSocketActorTest.java
+++ b/test/io/pathfinder/websockets/WebSocketActorTest.java
@@ -9,6 +9,7 @@ import io.pathfinder.BaseAppTest;
 import io.pathfinder.models.Cluster;
 import io.pathfinder.models.Commodity;
 import io.pathfinder.models.Vehicle;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,7 +33,7 @@ public class WebSocketActorTest extends BaseAppTest {
     private static final JsValue JSON_CREATE_COMMODITY =
         Json.parse("{\"create\":{\"model\":\"Commodity\",\"value\":{\"startLatitude\":0.1,\"startLongitude\":-12.3,\"endLatitude\":99.4,\"endLongitude\":-3.5,\"clusterId\":1,\"param\":5}}}");
     private static final JsValue JSON_GET_CLUSTERS =
-        Json.parse("{\"getClusters\":{\"id\":\"ABCDEFG\"}");
+        Json.parse("{\"getApplicationCluster\":{\"id\":\""+APPLICATION_ID+"\"}}");
 
     private static final int TIMEOUT = 3000;
 
@@ -86,6 +87,6 @@ public class WebSocketActorTest extends BaseAppTest {
     @Test
     public void testGetClusters() {
         Patterns.ask(socket, WebSocketMessage.format().reads(JSON_GET_CLUSTERS).get(), TIMEOUT);
-        client.expectMsg(new WebSocketMessage.GetClusters("ABCDEFG"));
+        client.expectMsg(new WebSocketMessage.ApplicationCluster(APPLICATION_ID,1L));
     }
 }


### PR DESCRIPTION
If running in the in-memory-server, you should add code into io.pathfinder.config.Global in order to have an application to test with(don't commit it though):

```
    public void onStart(Application app) {
        Logger.info("Application has started.");
        PathFinderApplication pfApp = new PathFinderApplication();
        pfApp.name_$eq("TEST APP");
        pfApp.insert();
        Cluster c = new Cluster();
        c.pathFinderApplication_$eq(pfApp);
        c.insert();
        pfApp.defaultCluster_$eq(c);
        c.save();
        pfApp.save();
        Logger.info("Created TEST APP with key: "+pfApp.id());
        Router.init();
    }
```

Otherwise, you can add the application through the pathfinder website.
you can then use the application id to make a request:

```
webSocket.send(JSON.stringify(
  { "getClusters": {"id": "001e7047-ee14-40d6-898a-5acf3a1cfd8a"} }
));
```

Which responds with the following message of the form:

```
{ "clusters": {
  "id": "001e7047-ee14-40d6-898a-5acf3a1cfd8a",
  "defaultClusterId": 10,
  "clusterIds": [10, 20, 30, 45]
}}
```
