### PR TITLE
Fix cluster router disappearing

### DIFF
--- a/app/io/pathfinder/routing/ClusterRouter.scala
+++ b/app/io/pathfinder/routing/ClusterRouter.scala
@@ -57,7 +57,7 @@ class ClusterRouter(clusterId: Long) extends EventBusActor with ActorEventBus wi
 
     private def recalculate(): Unit = {
         val cluster: Cluster = Cluster.Dao.read(clusterId).getOrElse{
-            self ! PoisonPill
+            Logger.warn("Cluster with id: "+clusterId+" missing")
             return
         }
         val vehicles = cluster.vehicles

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ routesGenerator := InjectedRoutesGenerator
 
 // Docker configuration
 packageName in Docker := "pathfinder-server"
-version in Docker := "0.2.4"
+version in Docker := "0.2.5"
 maintainer in Docker := "Pathfinder Team"
 dockerRepository := Some("beta.gcr.io/phonic-aquifer-105721")
 dockerExposedPorts := Seq(9000, 9443)


### PR DESCRIPTION
The cluster routers were programmed to be created and deleted as clusters are created and deleted. This is problematic when the database restore script is ran because it kills all of the cluster routers. Cluster Routers now should not die.
