### PR TITLE
Subclusters

### DIFF
--- a/app/io/pathfinder/config/Global.scala
+++ b/app/io/pathfinder/config/Global.scala
@@ -16,7 +16,7 @@ object Global extends GlobalSettings {
 
     override def onStart(app: Application) {
         Logger.info("Application has started.")
-        Router.init()
+        Router
     }
 
     override def onStop(app: Application) {

--- a/app/io/pathfinder/models/Cluster.scala
+++ b/app/io/pathfinder/models/Cluster.scala
@@ -5,26 +5,24 @@ import javax.persistence.{JoinColumn, ManyToOne, OneToMany, CascadeType, Id, Gen
 
 import com.avaje.ebean.Model
 import io.pathfinder.data.{ObserverDao, Resource}
-import io.pathfinder.routing.Router
-import io.pathfinder.websockets.Events
 import play.api.libs.json.{Json, Format}
 import scala.collection.JavaConverters.asScalaBufferConverter
-import scala.collection.mutable
+import scala.collection.{mutable, Iterator}
 
 object Cluster {
     val finder: Model.Find[Long, Cluster] = new Model.Finder[Long, Cluster](classOf[Cluster])
     object Dao extends ObserverDao[Cluster](finder) {
 
         override protected def onCreated(model: Cluster): Unit = {
-            Router.ref ! (Events.Created, model)
+
         }
 
         override protected def onUpdated(model: Cluster): Unit = {
-            // clusters do not get updated
+
         }
 
         override protected def onDeleted(model: Cluster): Unit = {
-            Router.ref ! (Events.Deleted, model)
+
         }
     }
 
@@ -34,6 +32,7 @@ object Cluster {
     implicit val resourceFormat: Format[ClusterResource] = Json.format[ClusterResource]
 
     case class ClusterResource(
+        parentId: Option[Long],
         vehicles: Option[Seq[Vehicle.VehicleResource]],
         commodities: Option[Seq[Commodity.CommodityResource]]
     ) extends Resource[Cluster] {
@@ -43,6 +42,12 @@ object Cluster {
         /** Creates a new model instance from this resource. */
         override def create: Option[Cluster] = {
             val model = new Cluster
+            parentId.foreach(
+                clusterId =>
+                    model.parent = Some(
+                        Cluster.Dao.read(clusterId).getOrElse(return None)
+                    )
+            )
             vehicles.foreach(
                 _.foreach {
                     vehicleResource => model.vehicles += (
@@ -69,16 +74,17 @@ object Cluster {
         }
     }
 
-    def apply(id: Long, vehicles: Seq[Vehicle], commodities: Seq[Commodity]): Cluster = {
+    def apply(id: Long, vehicles: Seq[Vehicle], commodities: Seq[Commodity], subClusters: Seq[Cluster]): Cluster = {
         val c = new Cluster
         c.id = id
         c.vehicles ++= vehicles
         c.commodities ++= commodities
+        c.subClusters ++= subClusters
         c
     }
 
-    def unapply(c: Cluster): Option[(Long, Seq[Vehicle], Seq[Commodity])] =
-        Some((c.id, c.vehicles, c.commodities))
+    def unapply(c: Cluster): Option[(Long, Seq[Vehicle], Seq[Commodity], Seq[Cluster])] =
+        Some((c.id, c.vehicles, c.commodities, c.subClusters))
 }
 
 @Entity
@@ -87,6 +93,10 @@ class Cluster() extends Model with HasId {
     @Column(nullable = false)
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long = 0
+
+    @ManyToOne
+    @JoinColumn(name="parent_id", nullable = true)
+    var parentCluster: Cluster = null
 
     @Column
     var authenticationToken: Array[Byte] = "top secret".getBytes
@@ -97,8 +107,28 @@ class Cluster() extends Model with HasId {
     @OneToMany(mappedBy = "cluster", cascade=Array(CascadeType.ALL))
     var commodityList: util.List[Commodity] = new util.ArrayList[Commodity]()
 
+    @OneToMany(mappedBy = "parentCluster", cascade=Array(CascadeType.ALL))
+    var clusterList: util.List[Cluster] = new util.ArrayList[Cluster]()
+
     def vehicles: mutable.Buffer[Vehicle] = vehicleList.asScala
+
     def commodities: mutable.Buffer[Commodity] = commodityList.asScala
+
+    def subClusters: mutable.Buffer[Cluster] = clusterList.asScala
+
+    def parent: Option[Cluster] = Option(parentCluster)
+
+    def parent_=(opt: Option[Cluster]): Unit = parentCluster = opt.orNull
+
+    def parents: Iterator[Cluster] =
+        Iterator.iterate[Option[Cluster]](
+            Some(this)
+        )(
+            _.flatMap(_.parent)
+        ).takeWhile(_.isDefined).map(_.get)
+
+    def descendants: Iterator[Cluster] =             // each level            // combine all the levels
+        Iterator.iterate(subClusters.iterator)(_.map(_.subClusters).flatten).flatten
 
     override def toString = String.format(
         "Cluster(id: %s, vehicles: %s, commodities: %s)",

--- a/app/io/pathfinder/websockets/WebSocketActor.scala
+++ b/app/io/pathfinder/websockets/WebSocketActor.scala
@@ -57,7 +57,7 @@ class WebSocketActor (
                         }.getOrElse(Error("Subscribe requires either a model id or a cluster id"))
                     }.getOrElse(Error ("Can only subscribe to vehicles or commodities"))
                 case RouteSubscribe(model, id) =>
-                    if(Router.RouteSubscriber.subscribe(client, model, id))
+                    if(Router.subscribeToRoute(client, model, id))
                         client ! RouteSubscribed(model, id)
                     else
                         client ! Error("id: "+id+" not found for model: "+model)

--- a/app/io/pathfinder/websockets/pushing/SocketMessagePusher.scala
+++ b/app/io/pathfinder/websockets/pushing/SocketMessagePusher.scala
@@ -2,7 +2,6 @@ package io.pathfinder.websockets.pushing
 
 import akka.actor.{Props, ActorRef}
 import akka.event.{LookupClassification, ActorEventBus}
-import io.pathfinder.websockets.WebSocketMessage
 import play.Logger
 
 object SocketMessagePusher {
@@ -11,7 +10,7 @@ object SocketMessagePusher {
 
 class SocketMessagePusher[K] extends EventBusActor with ActorEventBus with LookupClassification {
 
-    override type Event = (K, WebSocketMessage) // id and message
+    override type Event = (K, Any) // id and message
 
     override type Classifier = K // cluster id
 

--- a/test/io/pathfinder/models/ClusterTest.java
+++ b/test/io/pathfinder/models/ClusterTest.java
@@ -92,15 +92,15 @@ public class ClusterTest {
         vehicle2.save();
         vehicle3.save();
 
-        Cluster cluster4 = Cluster.apply(id_count++, newList(), newList());
+        Cluster cluster4 = Cluster.apply(id_count++, newList(), newList(), newList());
         cluster4.save();
-        Cluster cluster3 = Cluster.apply(id_count++, newList(), newList());
+        Cluster cluster3 = Cluster.apply(id_count++, newList(), newList(), newList());
         cluster3.save();
-        Cluster cluster2 = Cluster.apply(id_count++, wrap(Arrays.asList(vehicle3.id())), wrap(Arrays.asList(commodity3.id())));
+        Cluster cluster2 = Cluster.apply(id_count++, wrap(Arrays.asList(vehicle3.id())), wrap(Arrays.asList(commodity3.id())), newList());
         cluster2.save();
-        Cluster cluster1 = Cluster.apply(id_count++, wrap(Arrays.asList(vehicle2.id())), wrap(Arrays.asList(commodity2.id())));
+        Cluster cluster1 = Cluster.apply(id_count++, wrap(Arrays.asList(vehicle2.id())), wrap(Arrays.asList(commodity2.id())), newList());
         cluster1.save();
-        Cluster mainCluster = Cluster.apply(id_count++, newList(), newList());
+        Cluster mainCluster = Cluster.apply(id_count++, newList(), newList(), wrap(Arrays.asList(cluster1,cluster2,cluster3,cluster4)));
         mainCluster.save();
         return mainCluster;
     }


### PR DESCRIPTION
Added support for subclusters, when routing a cluster, all of the vehicles and commodities in the cluster and its children are routed together, and all cluster json representations now contain a subCluster list. I also made the global Router object not an actor because it made the code too confusing and there was not any reason to do it that way.
