### PR TITLE
Routing fixes

### DIFF
--- a/app/io/pathfinder/routing/ClusterRouter.scala
+++ b/app/io/pathfinder/routing/ClusterRouter.scala
@@ -4,7 +4,7 @@ import akka.actor.{ActorRef, Props}
 import akka.event.{ActorEventBus, LookupClassification}
 import com.avaje.ebean.Model
 import io.pathfinder.models.{VehicleStatus, CommodityStatus, ModelId, Commodity, Vehicle, Cluster}
-import io.pathfinder.routing.Action.{DropOff, PickUp}
+import io.pathfinder.routing.Action.{Start, DropOff, PickUp}
 import io.pathfinder.routing.ClusterRouter.ClusterRouterMessage.{RouteRequest, ClusterEvent}
 import io.pathfinder.websockets.WebSocketMessage.{Error, Routed}
 import io.pathfinder.websockets.pushing.EventBusActor
@@ -228,27 +228,25 @@ class ClusterRouter(clusterPath: String) extends EventBusActor with ActorEventBu
             routes => Success(routes)
         )
 
-    private def recalculate(): Future[Seq[Route]] = {
+    private def recalculate(): Future[(Seq[Route], Seq[Commodity])] = {
         val cluster: Cluster = Cluster.Dao.read(clusterPath).getOrElse{
             Logger.warn("Cluster with id: "+clusterPath+" missing")
             return Future.failed(null)
         }
         Logger.info("RECALCULATING")
         val vehicles = cluster.vehicles.filter(v => VehicleStatus.Online.equals(v.status))
-        if (vehicles.size <= 0) {
-            Logger.info("Someone asked Router to recalculate but there are no vehicles in cluster.")
-            return Future.failed(null)
-        }
-        Logger.info("GOT VEHICLES")
         val commodities = cluster.commodities.filter(
             c => CommodityStatus.Waiting.equals(c.status) || CommodityStatus.PickedUp.equals(c.status)
         )
+        if (vehicles.size <= 0) {
+            Logger.info("Someone asked Router to recalculate but there are no vehicles in cluster.")
+            return Future.successful((Seq.empty, commodities))
+        }
 
         if (commodities.size <= 0) {
             Logger.info("someone asked for Router to recalculate but there are no commodities in cluster")
-            return Future.failed(null)
+            return Future.successful((vehicles.map(v => Route(v, Seq(new Action.Start(v)))), Seq.empty))
         }
-        Logger.info("GOT COMMODITIES")
 
         val starts = vehicles.map(x => (x.latitude, x.longitude))
         val pickups = commodities.map(c => (c.startLatitude, c.startLongitude))

--- a/app/io/pathfinder/routing/ClusterRouter.scala
+++ b/app/io/pathfinder/routing/ClusterRouter.scala
@@ -169,7 +169,7 @@ class ClusterRouter(clusterPath: String) extends EventBusActor with ActorEventBu
             }) {
                 e match {
                     case ClusterEvent(Events.Updated, v: Vehicle) =>
-                        cachedRoutes.flatMap { routes =>
+                        cachedRoutes.flatMap { case (routes, coms) =>
                             var found = 0
                             val replacement = routes.map { route =>
                                 if (route.vehicle.id == v.id) {
@@ -179,7 +179,7 @@ class ClusterRouter(clusterPath: String) extends EventBusActor with ActorEventBu
                             }
                             if (found == 1) {
                                 // good to go
-                                Some(replacement)
+                                Some((replacement, coms))
                             } else {
                                 Logger.warn(
                                     "Received vehicle update for vehicle:" + v.id + " with " + found + " routes in cluster:" + clusterPath + ", routing is probably broken."
@@ -190,7 +190,7 @@ class ClusterRouter(clusterPath: String) extends EventBusActor with ActorEventBu
                             Logger.info("Updating vehicle position for vehicle:" + v.id + " without recalculating routes")
                             val newRoutes = routeTry.getOrElse {
                                 // TODO: handle errors here
-                                Logger.warn("Error updating routes for cluster: " + clusterPath);
+                                Logger.warn("Error updating routes for cluster: " + clusterPath)
                                 return PartialFunction.empty
                             }
                             cachedRoutes = Some(newRoutes)

--- a/app/io/pathfinder/routing/Router.scala
+++ b/app/io/pathfinder/routing/Router.scala
@@ -32,6 +32,7 @@ object Router extends ActorEventBus with SubchannelClassification {
             if(!subs.contains(c.id)) {
                 val ref = Global.actorSystem.actorOf(ClusterRouter.props(c))
                 if (subscribe(ref, c.id)) {
+                    Logger.info("adding cluster router: " + ref + ", to cluster: " + c.id)
                     subs.put(c.id, ref)
                 } else {
                     Global.actorSystem.stop(ref)
@@ -77,6 +78,7 @@ object Router extends ActorEventBus with SubchannelClassification {
         if(!subs.contains(cluster.id)){
             add(cluster.id)
         }
+        Logger.info(client + " is subscribing to :" + id)
         publish((cluster.id, Subscribe(client, id)))
         publish(cluster, RouteRequest(client, id))
         true

--- a/app/io/pathfinder/websockets/WebSocketMessage.scala
+++ b/app/io/pathfinder/websockets/WebSocketMessage.scala
@@ -1,6 +1,6 @@
 package io.pathfinder.websockets
 
-import io.pathfinder.models.{Cluster, ModelId}
+import io.pathfinder.models.{Commodity, Cluster, ModelId}
 import io.pathfinder.websockets.WebSocketMessage.MessageCompanion
 import play.Logger
 import play.api.libs.json.{JsSuccess, JsResult, Format, Json, JsValue, __}
@@ -292,13 +292,16 @@ object WebSocketMessage {
     }
     addComp(Route)
 
+
+    private implicit val cFormat = io.pathfinder.models.Commodity.format
     /**
      * Response for a route request
      */
     case class Routed(
         model: ModelType,
         value: JsValue,
-        route: JsValue
+        route: JsValue,
+        unroutedCommodities: Option[Seq[Commodity]]
     ) extends ControllerMessage {
         override type M = Routed
         override def companion = Routed

--- a/app/io/pathfinder/websockets/pushing/EventBusActor.scala
+++ b/app/io/pathfinder/websockets/pushing/EventBusActor.scala
@@ -3,6 +3,7 @@ package io.pathfinder.websockets.pushing
 import akka.actor.{Actor, ActorRef}
 import akka.event.ActorEventBus
 import io.pathfinder.websockets.pushing.EventBusActor.EventBusMessage.{UnsubscribeAll, Unsubscribe, Publish, Subscribe}
+import play.Logger
 
 object EventBusActor {
     abstract sealed class EventBusMessage
@@ -18,7 +19,9 @@ object EventBusActor {
 abstract class EventBusActor extends Actor with ActorEventBus {
 
     override def receive: Receive = {
-        case Subscribe(sub, to)     => subscribe(sub, to.asInstanceOf[Classifier])
+        case Subscribe(sub, to)     =>
+            Logger.info(sub.toString() + " subcribed to "+this.toString)
+            subscribe(sub, to.asInstanceOf[Classifier])
         case Unsubscribe(sub, from) => unsubscribe(sub, from.asInstanceOf[Classifier])
         case UnsubscribeAll(sub)    => unsubscribe(sub)
         case Publish(event)         => publish(event.asInstanceOf[Event])


### PR DESCRIPTION
This fixes and optimizes some things with routing. Updating a vehicle's position or updating an offline vehicle does not cause a reroute, unrouted commodities are included in the routing message and I fixed a problem where routed messages were sometimes not sent for subclusters when subscribed to their super cluster.
