### PR TITLE
removed parentheses from latlngs in distancematrix url in ClusterRouter

### DIFF
--- a/app/io/pathfinder/routing/ClusterRouter.scala
+++ b/app/io/pathfinder/routing/ClusterRouter.scala
@@ -62,12 +62,12 @@ object ClusterRouter {
         def makeRequest(origins: TraversableOnce[(Double, Double)], dests: TraversableOnce[(Double, Double)]): Future[WSResponse] = {
             val req = apiKey.fold {
                 googleMaps.withQueryString(
-                    "origins" -> origins.map(latlng => f"(${latlng._1}%.4f,${latlng._2}%.4f)").mkString("|"),
-                    "destinations" -> dests.map(latlng => f"(${latlng._1}%.4f,${latlng._2}%.4f)").mkString("|"))
+                    "origins" -> origins.map(latlng => f"${latlng._1}%.4f,${latlng._2}%.4f").mkString("|"),
+                    "destinations" -> dests.map(latlng => f"${latlng._1}%.4f,${latlng._2}%.4f").mkString("|"))
             } { key =>
                 googleMaps.withQueryString(
-                    "origins" -> origins.map(latlng => f"(${latlng._1}%.4f,${latlng._2}%.4f)").mkString("|"),
-                    "destinations" -> dests.map(latlng => f"(${latlng._1}%.4f,${latlng._2}%.4f)").mkString("|"),
+                    "origins" -> origins.map(latlng => f"${latlng._1}%.4f,${latlng._2}%.4f").mkString("|"),
+                    "destinations" -> dests.map(latlng => f"${latlng._1}%.4f,${latlng._2}%.4f").mkString("|"),
                     "key" -> key)
             }
             Logger.info(req.toString)


### PR DESCRIPTION
the distancematrix url now requires that latlngs do not use parentheses so they have been removed.
