### PR TITLE
Add recalculate message

### DIFF
--- a/app/io/pathfinder/routing/Router.scala
+++ b/app/io/pathfinder/routing/Router.scala
@@ -104,7 +104,8 @@ object Router extends ActorEventBus with SubchannelClassification {
     def recalculate(client: ActorRef, clusterId: String): Unit = {
         if(subs.contains(clusterId) || Cluster.Dao.read(clusterId).exists(c => add(clusterId))) {
             publish((clusterId, ClusterRouterMessage.Recalculate(client)))
+        } else {
+            client ! WebSocketMessage.Error("No Cluster with id: " + Cluster.removeAppFromPath(clusterId) + " found")
         }
-        client ! WebSocketMessage.Error("No Cluster with id: " + Cluster.removeAppFromPath(clusterId) + " found")
     }
 }

--- a/app/io/pathfinder/routing/Router.scala
+++ b/app/io/pathfinder/routing/Router.scala
@@ -10,7 +10,7 @@ import io.pathfinder.models.{ModelId, HasCluster, Cluster, Commodity, Vehicle}
 import io.pathfinder.routing.ClusterRouter.ClusterRouterMessage
 import io.pathfinder.routing.ClusterRouter.ClusterRouterMessage.{RouteRequest, ClusterEvent}
 import io.pathfinder.websockets.pushing.EventBusActor.EventBusMessage.Subscribe
-import io.pathfinder.websockets.Events
+import io.pathfinder.websockets.{WebSocketMessage, Events}
 import play.Logger
 import scala.collection.mutable
 import scala.concurrent.duration.{FiniteDuration, DurationInt}
@@ -99,5 +99,12 @@ object Router extends ActorEventBus with SubchannelClassification {
 
     def publish(event: Events.Value, model: HasCluster): Unit = {
         publish(model.cluster, ClusterEvent(event, model))
+    }
+
+    def recalculate(client: ActorRef, clusterId: String): Unit = {
+        if(subs.contains(clusterId) || Cluster.Dao.read(clusterId).exists(c => add(clusterId))) {
+            publish((clusterId, ClusterRouterMessage.Recalculate(client)))
+        }
+        client ! WebSocketMessage.Error("No Cluster with id: " + Cluster.removeAppFromPath(clusterId) + " found")
     }
 }

--- a/app/io/pathfinder/websockets/WebSocketActor.scala
+++ b/app/io/pathfinder/websockets/WebSocketActor.scala
@@ -55,6 +55,8 @@ class WebSocketActor (
                     else
                         client ! Error("id: "+id.toString+" not found for model: "+id.modelType.toString)
 
+                case Recalculate(cId) =>
+                    Router.recalculate(client, cId)
                 case c: ControllerMessage => controllers.get(c.model).flatMap(_.receive(c, app)).foreach(client ! _)
 
                 case Subscribe(None, _model, Some(id)) =>

--- a/app/io/pathfinder/websockets/WebSocketMessage.scala
+++ b/app/io/pathfinder/websockets/WebSocketMessage.scala
@@ -439,6 +439,23 @@ object WebSocketMessage {
     }
     addComp(Unsubscribed)
 
+    case class Recalculate(
+        clusterId: String
+    ) extends WebSocketMessage {
+        override type M = Recalculate
+        override def companion: MessageCompanion[M] = Recalculate
+        override def withApp(app: String): Option[Recalculate] =
+            Cluster.addAppToPath(clusterId, app).map(id => copy(clusterId = id))
+        override def withoutApp: Recalculate =
+            copy(clusterId = Cluster.removeAppFromPath(clusterId))
+    }
+
+    object Recalculate extends MessageCompanion[Recalculate] {
+        override def message: String = "Recalculate"
+        override def format: Format[Recalculate] = Json.format[Recalculate]
+    }
+    addComp(Recalculate)
+
     val stringToMessage: Map[String, _ <: MessageCompanion[_]] = builder.result()
 
     Logger.info("stringToMessage: [" + stringToMessage.keys.mkString("|")+"]")

--- a/app/io/pathfinder/websockets/WebSocketMessage.scala
+++ b/app/io/pathfinder/websockets/WebSocketMessage.scala
@@ -456,6 +456,23 @@ object WebSocketMessage {
     }
     addComp(Recalculate)
 
+    case class Recalculated(
+        clusterId: String
+    ) extends WebSocketMessage {
+        override type M = Recalculated
+        override def companion = Recalculated
+        override def withApp(app: String): Option[Recalculated] =
+            Cluster.addAppToPath(clusterId, app).map(id => copy(clusterId = id))
+        override def withoutApp: Recalculated =
+            copy(clusterId = Cluster.removeAppFromPath(clusterId))
+    }
+
+    object Recalculated extends MessageCompanion[Recalculated] {
+        override def message = "Recalculated"
+        override def format: Format[Recalculated] = Json.format[Recalculated]
+    }
+    addComp(Recalculated)
+
     val stringToMessage: Map[String, _ <: MessageCompanion[_]] = builder.result()
 
     Logger.info("stringToMessage: [" + stringToMessage.keys.mkString("|")+"]")


### PR DESCRIPTION
this adds the recalculate message, it looks like this:

`{ "message":"Recalculate", "clusterId":"/root/subcluster" }`

This message recalculates the specified route, when it succeeds, it returns a recalculated message

`{ "message":"Recalculated", "clusterId":"/root/subcluster" }`

Otherwise it might return an error message
