### PR TITLE
Prevent route request spamming

### DIFF
--- a/app/io/pathfinder/routing/ClusterRoute.scala
+++ b/app/io/pathfinder/routing/ClusterRoute.scala
@@ -1,0 +1,17 @@
+package io.pathfinder.routing
+
+import io.pathfinder.models.{Cluster, Commodity}
+import io.pathfinder.websockets.ModelTypes
+import io.pathfinder.websockets.WebSocketMessage.Routed
+import play.api.libs.json.{Writes, JsString, JsObject}
+
+case class ClusterRoute(id: String, routes: Seq[Route], unroutedCommodities: Seq[Commodity]) {
+    def routed: Routed = Routed(
+        ModelTypes.Cluster,
+        JsObject(Seq(
+            "id" -> JsString(Cluster.removeAppFromPath(id))
+        )),
+        Writes.seq(Route.writes).writes(routes),
+        Some(unroutedCommodities)
+    )
+}

--- a/app/io/pathfinder/routing/ClusterRouter.scala
+++ b/app/io/pathfinder/routing/ClusterRouter.scala
@@ -245,6 +245,7 @@ class ClusterRouter(clusterPath: String) extends EventBusActor with ActorEventBu
         futureRoutes.onComplete { routeTry =>
             routeTry.map { cr =>
                 synchronized {
+                    Logger.info("Update received: " + cachedRoutes.version + " == " + version)
                     if(cachedRoutes.version == version) {
                         handleEvents(cachedRoutes.events, cr) match {
                             case (ncr, true) =>

--- a/app/io/pathfinder/routing/ClusterRouter.scala
+++ b/app/io/pathfinder/routing/ClusterRouter.scala
@@ -295,9 +295,10 @@ class ClusterRouter(clusterPath: String) extends EventBusActor with ActorEventBu
                 synchronized {
                     cachedRoutes match {
                         case UpToDate(cr, v) =>
-                            cachedRoutes = handleEvent(e, cr).map(
-                                UpToDate(_, v + 1)
-                            ).getOrElse {
+                            cachedRoutes = handleEvent(e, cr).map { ncr =>
+                                publish(ncr)
+                                UpToDate(ncr, v + 1)
+                            }.getOrElse {
                                 val ncrf = recalculate()
                                 handleUpdating(ncrf, v + 1)
                                 Updating(ncrf, Seq.empty, v + 1)


### PR DESCRIPTION
this makes cluster routing only make 1 request at a time. I did some basic tests so make sure it works, including recalculates, updates, vehicle location updates and sequential recalculates and updates. I am doing more tests so don't pull it yet.
